### PR TITLE
Replace `go build` by `go install`

### DIFF
--- a/init.el
+++ b/init.el
@@ -45,7 +45,7 @@
   (setq gofmt-command "goimports")                ; gofmt uses invokes goimports
   (if (not (string-match "go" compile-command))   ; set compile command default
       (set (make-local-variable 'compile-command)
-	   "go build -i -v && go test -v && go vet"))
+	   "go install -i -v && go test -v && go vet"))
 
   ;; guru settings
   (go-guru-hl-identifier-mode)                    ; highlight identifiers


### PR DESCRIPTION
`go build` generates the binary in the source tree. It is inconvenient to tell Git to ignore all these binary files. `go install` generates files into  `$GOPATH/bin`, which is out of the source tree.